### PR TITLE
Install ansible dependencies.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,12 @@ env:
   - distro: debian10
 
 before_install:
+  - sudo pip install --upgrade pip
+  - sudo pip install ansible
   - go get -v github.com/fubarhouse/ansible-role-tester
 
 script:
-  - ansible-role-tester full --user fubarhouse --distribution ${distro} --destination /etc/ansible/roles/$(basename $(pwd))
+  - ansible-role-tester full --distribution ${distro}
 
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -35,5 +35,5 @@ galaxy_info:
     - source
     - makefile
 
-  # No dependencies.
-  dependencies: []
+# No dependencies.
+dependencies: []


### PR DESCRIPTION
Build are [failing](https://travis-ci.org/issmirnov/ansible-role-compile-zsh/jobs/430807628):
```
ERRO[0000] executable 'ansible-playbook' was not found in $PATH. 
```

Looks like we need to explicitly install ansible on the local machine. Not sure why this worked earlier - probably due to @fubarhouse having ansible present in their docker images.